### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -28,7 +28,7 @@ def _basic_auth_str(username, password):
     """Returns a Basic Auth string."""
 
     authstr = 'Basic ' + to_native_string(
-        b64encode(('%s:%s' % (username, password)).encode('latin1')).strip()
+        b64encode(('{0!s}:{1!s}'.format(username, password)).encode('latin1')).strip()
     )
 
     return authstr
@@ -112,7 +112,7 @@ class HTTPDigestAuth(AuthBase):
                 return hashlib.sha1(x).hexdigest()
             hash_utf8 = sha_utf8
 
-        KD = lambda s, d: hash_utf8("%s:%s" % (s, d))
+        KD = lambda s, d: hash_utf8("{0!s}:{1!s}".format(s, d))
 
         if hash_utf8 is None:
             return None
@@ -125,8 +125,8 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += '?' + p_parsed.query
 
-        A1 = '%s:%s:%s' % (self.username, realm, self.password)
-        A2 = '%s:%s' % (method, path)
+        A1 = '{0!s}:{1!s}:{2!s}'.format(self.username, realm, self.password)
+        A2 = '{0!s}:{1!s}'.format(method, path)
 
         HA1 = hash_utf8(A1)
         HA2 = hash_utf8(A2)
@@ -135,7 +135,7 @@ class HTTPDigestAuth(AuthBase):
             self._thread_local.nonce_count += 1
         else:
             self._thread_local.nonce_count = 1
-        ncvalue = '%08x' % self._thread_local.nonce_count
+        ncvalue = '{0:08x}'.format(self._thread_local.nonce_count)
         s = str(self._thread_local.nonce_count).encode('utf-8')
         s += nonce.encode('utf-8')
         s += time.ctime().encode('utf-8')
@@ -143,12 +143,12 @@ class HTTPDigestAuth(AuthBase):
 
         cnonce = (hashlib.sha1(s).hexdigest()[:16])
         if _algorithm == 'MD5-SESS':
-            HA1 = hash_utf8('%s:%s:%s' % (HA1, nonce, cnonce))
+            HA1 = hash_utf8('{0!s}:{1!s}:{2!s}'.format(HA1, nonce, cnonce))
 
         if not qop:
-            respdig = KD(HA1, "%s:%s" % (nonce, HA2))
+            respdig = KD(HA1, "{0!s}:{1!s}".format(nonce, HA2))
         elif qop == 'auth' or 'auth' in qop.split(','):
-            noncebit = "%s:%s:%s:%s:%s" % (
+            noncebit = "{0!s}:{1!s}:{2!s}:{3!s}:{4!s}".format(
                 nonce, ncvalue, cnonce, 'auth', HA2
                 )
             respdig = KD(HA1, noncebit)
@@ -162,15 +162,15 @@ class HTTPDigestAuth(AuthBase):
         base = 'username="%s", realm="%s", nonce="%s", uri="%s", ' \
                'response="%s"' % (self.username, realm, nonce, path, respdig)
         if opaque:
-            base += ', opaque="%s"' % opaque
+            base += ', opaque="{0!s}"'.format(opaque)
         if algorithm:
-            base += ', algorithm="%s"' % algorithm
+            base += ', algorithm="{0!s}"'.format(algorithm)
         if entdig:
-            base += ', digest="%s"' % entdig
+            base += ', digest="{0!s}"'.format(entdig)
         if qop:
-            base += ', qop="auth", nc=%s, cnonce="%s"' % (ncvalue, cnonce)
+            base += ', qop="auth", nc={0!s}, cnonce="{1!s}"'.format(ncvalue, cnonce)
 
-        return 'Digest %s' % (base)
+        return 'Digest {0!s}'.format((base))
 
     def handle_redirect(self, r, **kwargs):
         """Reset num_401_calls counter on redirects."""

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -329,7 +329,7 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
                     if path is None or cookie.path == path:
                         return cookie.value
 
-        raise KeyError('name=%r, domain=%r, path=%r' % (name, domain, path))
+        raise KeyError('name={0!r}, domain={1!r}, path={2!r}'.format(name, domain, path))
 
     def _find_no_duplicates(self, name, domain=None, path=None):
         """Both ``__get_item__`` and ``get`` call this function: it's never
@@ -343,12 +343,12 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
                 if domain is None or cookie.domain == domain:
                     if path is None or cookie.path == path:
                         if toReturn is not None:  # if there are multiple cookies that meet passed in criteria
-                            raise CookieConflictError('There are multiple cookies with name, %r' % (name))
+                            raise CookieConflictError('There are multiple cookies with name, {0!r}'.format((name)))
                         toReturn = cookie.value  # we will eventually return this as long as no cookie conflict
 
         if toReturn:
             return toReturn
-        raise KeyError('name=%r, domain=%r, path=%r' % (name, domain, path))
+        raise KeyError('name={0!r}, domain={1!r}, path={2!r}'.format(name, domain, path))
 
     def __getstate__(self):
         """Unlike a normal CookieJar, this class is pickleable."""
@@ -428,7 +428,7 @@ def morsel_to_cookie(morsel):
         try:
             expires = int(time.time() + int(morsel['max-age']))
         except ValueError:
-            raise TypeError('max-age: %s must be integer' % morsel['max-age'])
+            raise TypeError('max-age: {0!s} must be integer'.format(morsel['max-age']))
     elif morsel['expires']:
         time_template = '%a, %d-%b-%Y %H:%M:%S GMT'
         expires = calendar.timegm(

--- a/requests/models.py
+++ b/requests/models.py
@@ -165,7 +165,7 @@ class RequestHooksMixin(object):
         """Properly register a hook."""
 
         if event not in self.hooks:
-            raise ValueError('Unsupported event specified, with event name "%s"' % (event))
+            raise ValueError('Unsupported event specified, with event name "{0!s}"'.format((event)))
 
         if isinstance(hook, collections.Callable):
             self.hooks[event].append(hook)
@@ -233,7 +233,7 @@ class Request(RequestHooksMixin):
         self.cookies = cookies
 
     def __repr__(self):
-        return '<Request [%s]>' % (self.method)
+        return '<Request [{0!s}]>'.format((self.method))
 
     def prepare(self):
         """Constructs a :class:`PreparedRequest <PreparedRequest>` for transmission and returns it."""
@@ -305,7 +305,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.prepare_hooks(hooks)
 
     def __repr__(self):
-        return '<PreparedRequest [%s]>' % (self.method)
+        return '<PreparedRequest [{0!s}]>'.format((self.method))
 
     def copy(self):
         p = PreparedRequest()
@@ -355,7 +355,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             raise MissingSchema(error)
 
         if not host:
-            raise InvalidURL("Invalid URL %r: No host supplied" % url)
+            raise InvalidURL("Invalid URL {0!r}: No host supplied".format(url))
 
         # Only want to apply IDNA to the hostname
         try:
@@ -393,7 +393,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         enc_params = self._encode_params(params)
         if enc_params:
             if query:
-                query = '%s&%s' % (query, enc_params)
+                query = '{0!s}&{1!s}'.format(query, enc_params)
             else:
                 query = enc_params
 
@@ -605,7 +605,7 @@ class Response(object):
         setattr(self, 'raw', None)
 
     def __repr__(self):
-        return '<Response [%s]>' % (self.status_code)
+        return '<Response [{0!s}]>'.format((self.status_code))
 
     def __bool__(self):
         """Returns true if :attr:`status_code` is 'OK'."""
@@ -833,10 +833,10 @@ class Response(object):
         http_error_msg = ''
 
         if 400 <= self.status_code < 500:
-            http_error_msg = '%s Client Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = '{0!s} Client Error: {1!s} for url: {2!s}'.format(self.status_code, self.reason, self.url)
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = '%s Server Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = '{0!s} Server Error: {1!s} for url: {2!s}'.format(self.status_code, self.reason, self.url)
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)

--- a/requests/packages/__init__.py
+++ b/requests/packages/__init__.py
@@ -27,10 +27,10 @@ try:
     from . import urllib3
 except ImportError:
     import urllib3
-    sys.modules['%s.urllib3' % __name__] = urllib3
+    sys.modules['{0!s}.urllib3'.format(__name__)] = urllib3
 
 try:
     from . import chardet
 except ImportError:
     import chardet
-    sys.modules['%s.chardet' % __name__] = chardet
+    sys.modules['{0!s}.chardet'.format(__name__)] = chardet

--- a/requests/packages/chardet/charsetgroupprober.py
+++ b/requests/packages/chardet/charsetgroupprober.py
@@ -93,8 +93,7 @@ class CharSetGroupProber(CharSetProber):
                 continue
             cf = prober.get_confidence()
             if constants._debug:
-                sys.stderr.write('%s confidence = %s\n' %
-                                 (prober.get_charset_name(), cf))
+                sys.stderr.write('{0!s} confidence = {1!s}\n'.format(prober.get_charset_name(), cf))
             if bestConf < cf:
                 bestConf = cf
                 self._mBestGuessProber = prober

--- a/requests/packages/chardet/universaldetector.py
+++ b/requests/packages/chardet/universaldetector.py
@@ -165,6 +165,5 @@ class UniversalDetector:
             for prober in self._mCharSetProbers[0].mProbers:
                 if not prober:
                     continue
-                sys.stderr.write('%s confidence = %s\n' %
-                                 (prober.get_charset_name(),
+                sys.stderr.write('{0!s} confidence = {1!s}\n'.format(prober.get_charset_name(),
                                   prober.get_confidence()))

--- a/requests/packages/urllib3/__init__.py
+++ b/requests/packages/urllib3/__init__.py
@@ -68,7 +68,7 @@ def add_stderr_logger(level=logging.DEBUG):
     handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
     logger.addHandler(handler)
     logger.setLevel(level)
-    logger.debug('Added a stderr logging handler to logger: %s' % __name__)
+    logger.debug('Added a stderr logging handler to logger: {0!s}'.format(__name__))
     return handler
 
 # ... Clean up.

--- a/requests/packages/urllib3/_collections.py
+++ b/requests/packages/urllib3/_collections.py
@@ -273,7 +273,7 @@ class HTTPHeaderDict(MutableMapping):
     iget = getlist
 
     def __repr__(self):
-        return "%s(%s)" % (type(self).__name__, dict(self.itermerged()))
+        return "{0!s}({1!s})".format(type(self).__name__, dict(self.itermerged()))
 
     def _copy_from(self, other):
         for key in other:

--- a/requests/packages/urllib3/connection.py
+++ b/requests/packages/urllib3/connection.py
@@ -138,12 +138,11 @@ class HTTPConnection(_HTTPConnection, object):
 
         except SocketTimeout as e:
             raise ConnectTimeoutError(
-                self, "Connection to %s timed out. (connect timeout=%s)" %
-                (self.host, self.timeout))
+                self, "Connection to {0!s} timed out. (connect timeout={1!s})".format(self.host, self.timeout))
 
         except SocketError as e:
             raise NewConnectionError(
-                self, "Failed to establish a new connection: %s" % e)
+                self, "Failed to establish a new connection: {0!s}".format(e))
 
         return conn
 

--- a/requests/packages/urllib3/connectionpool.py
+++ b/requests/packages/urllib3/connectionpool.py
@@ -73,7 +73,7 @@ class ConnectionPool(object):
         self.port = port
 
     def __str__(self):
-        return '%s(host=%r, port=%r)' % (type(self).__name__,
+        return '{0!s}(host={1!r}, port={2!r})'.format(type(self).__name__,
                                          self.host, self.port)
 
     def __enter__(self):
@@ -203,8 +203,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         Return a fresh :class:`HTTPConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTP connection (%d): %s" %
-                 (self.num_connections, self.host))
+        log.info("Starting new HTTP connection ({0:d}): {1!s}".format(self.num_connections, self.host))
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
                                   timeout=self.timeout.connect_timeout,
@@ -239,7 +238,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # If this is a persistent connection, check if it got disconnected
         if conn and is_connection_dropped(conn):
-            log.info("Resetting dropped connection: %s" % self.host)
+            log.info("Resetting dropped connection: {0!s}".format(self.host))
             conn.close()
             if getattr(conn, 'auto_open', 1) == 0:
                 # This is a proxied connection that has been mutated by
@@ -272,8 +271,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         except Full:
             # This should never happen if self.block == True
             log.warning(
-                "Connection pool is full, discarding connection: %s" %
-                self.host)
+                "Connection pool is full, discarding connection: {0!s}".format(
+                self.host))
 
         # Connection never got put back into the pool, close it.
         if conn:
@@ -305,18 +304,18 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         """Is the error actually a timeout? Will raise a ReadTimeout or pass"""
 
         if isinstance(err, SocketTimeout):
-            raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+            raise ReadTimeoutError(self, url, "Read timed out. (read timeout={0!s})".format(timeout_value))
 
         # See the above comment about EAGAIN in Python 3. In Python 2 we have
         # to specifically catch it and throw the timeout error
         if hasattr(err, 'errno') and err.errno in _blocking_errnos:
-            raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+            raise ReadTimeoutError(self, url, "Read timed out. (read timeout={0!s})".format(timeout_value))
 
         # Catch possible read timeouts thrown as SSL errors. If not the
         # case, rethrow the original. We need to do this because of:
         # http://bugs.python.org/issue10272
         if 'timed out' in str(err) or 'did not complete (read)' in str(err):  # Python 2.6
-            raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+            raise ReadTimeoutError(self, url, "Read timed out. (read timeout={0!s})".format(timeout_value))
 
     def _make_request(self, conn, method, url, timeout=_Default,
                       **httplib_request_kw):
@@ -364,7 +363,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # timeouts, check for a zero timeout before making the request.
             if read_timeout == 0:
                 raise ReadTimeoutError(
-                    self, url, "Read timed out. (read timeout=%s)" % read_timeout)
+                    self, url, "Read timed out. (read timeout={0!s})".format(read_timeout))
             if read_timeout is Timeout.DEFAULT_TIMEOUT:
                 conn.sock.settimeout(socket.getdefaulttimeout())
             else:  # None or a value
@@ -382,7 +381,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # AppEngine doesn't have a version attr.
         http_version = getattr(conn, '_http_vsn_str', 'HTTP/?')
-        log.debug("\"%s %s %s\" %s %s" % (method, url, http_version,
+        log.debug("\"{0!s} {1!s} {2!s}\" {3!s} {4!s}".format(method, url, http_version,
                                           httplib_response.status,
                                           httplib_response.length))
 
@@ -644,7 +643,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                     raise
                 return response
 
-            log.info("Redirecting %s -> %s" % (url, redirect_location))
+            log.info("Redirecting {0!s} -> {1!s}".format(url, redirect_location))
             return self.urlopen(
                 method, redirect_location, body, headers,
                 retries=retries, redirect=redirect,
@@ -656,7 +655,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if retries.is_forced_retry(method, status_code=response.status):
             retries = retries.increment(method, url, response=response, _pool=self)
             retries.sleep()
-            log.info("Forced retry: %s" % url)
+            log.info("Forced retry: {0!s}".format(url))
             return self.urlopen(
                 method, url, body, headers,
                 retries=retries, redirect=redirect,
@@ -754,8 +753,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         Return a fresh :class:`httplib.HTTPSConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTPS connection (%d): %s"
-                 % (self.num_connections, self.host))
+        log.info("Starting new HTTPS connection ({0:d}): {1!s}".format(self.num_connections, self.host))
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:
             raise SSLError("Can't connect to HTTPS URL because the SSL "

--- a/requests/packages/urllib3/contrib/appengine.py
+++ b/requests/packages/urllib3/contrib/appengine.py
@@ -130,7 +130,7 @@ class AppEngineManager(RequestMethods):
 
         except urlfetch.InvalidMethodError as e:
             raise AppEnginePlatformError(
-                "URLFetch does not support method: %s" % method, e)
+                "URLFetch does not support method: {0!s}".format(method), e)
 
         http_response = self._urlfetch_response_to_http_response(
             response, **response_kw)
@@ -144,7 +144,7 @@ class AppEngineManager(RequestMethods):
         if retries.is_forced_retry(method, status_code=http_response.status):
             retries = retries.increment(
                 method, url, response=http_response, _pool=self)
-            log.info("Forced retry: %s" % url)
+            log.info("Forced retry: {0!s}".format(url))
             retries.sleep()
             return self.urlopen(
                 method, url,

--- a/requests/packages/urllib3/contrib/ntlmpool.py
+++ b/requests/packages/urllib3/contrib/ntlmpool.py
@@ -43,8 +43,7 @@ class NTLMConnectionPool(HTTPSConnectionPool):
         # Performs the NTLM handshake that secures the connection. The socket
         # must be kept open while requests are performed.
         self.num_connections += 1
-        log.debug('Starting NTLM HTTPS connection no. %d: https://%s%s' %
-                  (self.num_connections, self.host, self.authurl))
+        log.debug('Starting NTLM HTTPS connection no. {0:d}: https://{1!s}{2!s}'.format(self.num_connections, self.host, self.authurl))
 
         headers = {}
         headers['Connection'] = 'Keep-Alive'
@@ -55,14 +54,14 @@ class NTLMConnectionPool(HTTPSConnectionPool):
 
         # Send negotiation message
         headers[req_header] = (
-            'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(self.rawuser))
-        log.debug('Request headers: %s' % headers)
+            'NTLM {0!s}'.format(ntlm.create_NTLM_NEGOTIATE_MESSAGE(self.rawuser)))
+        log.debug('Request headers: {0!s}'.format(headers))
         conn.request('GET', self.authurl, None, headers)
         res = conn.getresponse()
         reshdr = dict(res.getheaders())
-        log.debug('Response status: %s %s' % (res.status, res.reason))
-        log.debug('Response headers: %s' % reshdr)
-        log.debug('Response data: %s [...]' % res.read(100))
+        log.debug('Response status: {0!s} {1!s}'.format(res.status, res.reason))
+        log.debug('Response headers: {0!s}'.format(reshdr))
+        log.debug('Response data: {0!s} [...]'.format(res.read(100)))
 
         # Remove the reference to the socket, so that it can not be closed by
         # the response object (we want to keep the socket open)
@@ -75,8 +74,7 @@ class NTLMConnectionPool(HTTPSConnectionPool):
             if s[:5] == 'NTLM ':
                 auth_header_value = s[5:]
         if auth_header_value is None:
-            raise Exception('Unexpected %s response header: %s' %
-                            (resp_header, reshdr[resp_header]))
+            raise Exception('Unexpected {0!s} response header: {1!s}'.format(resp_header, reshdr[resp_header]))
 
         # Send authentication message
         ServerChallenge, NegotiateFlags = \
@@ -86,19 +84,18 @@ class NTLMConnectionPool(HTTPSConnectionPool):
                                                          self.domain,
                                                          self.pw,
                                                          NegotiateFlags)
-        headers[req_header] = 'NTLM %s' % auth_msg
-        log.debug('Request headers: %s' % headers)
+        headers[req_header] = 'NTLM {0!s}'.format(auth_msg)
+        log.debug('Request headers: {0!s}'.format(headers))
         conn.request('GET', self.authurl, None, headers)
         res = conn.getresponse()
-        log.debug('Response status: %s %s' % (res.status, res.reason))
-        log.debug('Response headers: %s' % dict(res.getheaders()))
-        log.debug('Response data: %s [...]' % res.read()[:100])
+        log.debug('Response status: {0!s} {1!s}'.format(res.status, res.reason))
+        log.debug('Response headers: {0!s}'.format(dict(res.getheaders())))
+        log.debug('Response data: {0!s} [...]'.format(res.read()[:100]))
         if res.status != 200:
             if res.status == 401:
                 raise Exception('Server rejected request: wrong '
                                 'username or password')
-            raise Exception('Wrong server response: %s %s' %
-                            (res.status, res.reason))
+            raise Exception('Wrong server response: {0!s} {1!s}'.format(res.status, res.reason))
 
         res.fp = None
         log.debug('Connection established')

--- a/requests/packages/urllib3/contrib/pyopenssl.py
+++ b/requests/packages/urllib3/contrib/pyopenssl.py
@@ -281,7 +281,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         try:
             ctx.load_verify_locations(ca_certs, ca_cert_dir)
         except OpenSSL.SSL.Error as e:
-            raise ssl.SSLError('bad ca_certs: %r' % ca_certs, e)
+            raise ssl.SSLError('bad ca_certs: {0!r}'.format(ca_certs), e)
     else:
         ctx.set_default_verify_paths()
 
@@ -304,7 +304,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
                 raise timeout('select timed out')
             continue
         except OpenSSL.SSL.Error as e:
-            raise ssl.SSLError('bad handshake: %r' % e)
+            raise ssl.SSLError('bad handshake: {0!r}'.format(e))
         break
 
     return WrappedSocket(cnx, sock)

--- a/requests/packages/urllib3/exceptions.py
+++ b/requests/packages/urllib3/exceptions.py
@@ -16,7 +16,7 @@ class PoolError(HTTPError):
     "Base exception for errors caused within a pool."
     def __init__(self, pool, message):
         self.pool = pool
-        HTTPError.__init__(self, "%s: %s" % (pool, message))
+        HTTPError.__init__(self, "{0!s}: {1!s}".format(pool, message))
 
     def __reduce__(self):
         # For pickling purposes.
@@ -73,7 +73,7 @@ class MaxRetryError(RequestError):
     def __init__(self, pool, url, reason=None):
         self.reason = reason
 
-        message = "Max retries exceeded with url: %s (Caused by %r)" % (
+        message = "Max retries exceeded with url: {0!s} (Caused by {1!r})".format(
             url, reason)
 
         RequestError.__init__(self, pool, url, message)
@@ -83,7 +83,7 @@ class HostChangedError(RequestError):
     "Raised when an existing pool gets a request for a foreign host."
 
     def __init__(self, pool, url, retries=3):
-        message = "Tried to open a foreign host with url: %s" % url
+        message = "Tried to open a foreign host with url: {0!s}".format(url)
         RequestError.__init__(self, pool, url, message)
         self.retries = retries
 
@@ -138,7 +138,7 @@ class LocationParseError(LocationValueError):
     "Raised when get_host or similar fails to parse the URL input."
 
     def __init__(self, location):
-        message = "Failed to parse: %s" % location
+        message = "Failed to parse: {0!s}".format(location)
         HTTPError.__init__(self, message)
 
         self.location = location
@@ -190,12 +190,12 @@ class ProxySchemeUnknown(AssertionError, ValueError):
     # TODO(t-8ch): Stop inheriting from AssertionError in v2.0.
 
     def __init__(self, scheme):
-        message = "Not supported proxy scheme %s" % scheme
+        message = "Not supported proxy scheme {0!s}".format(scheme)
         super(ProxySchemeUnknown, self).__init__(message)
 
 
 class HeaderParsingError(HTTPError):
     "Raised by assert_header_parsing, but we convert it to a log.warning statement."
     def __init__(self, defects, unparsed_data):
-        message = '%s, unparsed data: %r' % (defects or 'Unknown', unparsed_data)
+        message = '{0!s}, unparsed data: {1!r}'.format(defects or 'Unknown', unparsed_data)
         super(HeaderParsingError, self).__init__(message)

--- a/requests/packages/urllib3/fields.py
+++ b/requests/packages/urllib3/fields.py
@@ -33,7 +33,7 @@ def format_header_param(name, value):
         The value of the parameter, provided as a unicode string.
     """
     if not any(ch in value for ch in '"\\\r\n'):
-        result = '%s="%s"' % (name, value)
+        result = '{0!s}="{1!s}"'.format(name, value)
         try:
             result.encode('ascii')
         except UnicodeEncodeError:
@@ -43,7 +43,7 @@ def format_header_param(name, value):
     if not six.PY3:  # Python 2:
         value = value.encode('utf-8')
     value = email.utils.encode_rfc2231(value, 'utf-8')
-    value = '%s*=%s' % (name, value)
+    value = '{0!s}*={1!s}'.format(name, value)
     return value
 
 
@@ -144,12 +144,12 @@ class RequestField(object):
         sort_keys = ['Content-Disposition', 'Content-Type', 'Content-Location']
         for sort_key in sort_keys:
             if self.headers.get(sort_key, False):
-                lines.append('%s: %s' % (sort_key, self.headers[sort_key]))
+                lines.append('{0!s}: {1!s}'.format(sort_key, self.headers[sort_key]))
 
         for header_name, header_value in self.headers.items():
             if header_name not in sort_keys:
                 if header_value:
-                    lines.append('%s: %s' % (header_name, header_value))
+                    lines.append('{0!s}: {1!s}'.format(header_name, header_value))
 
         lines.append('\r\n')
         return '\r\n'.join(lines)

--- a/requests/packages/urllib3/filepost.py
+++ b/requests/packages/urllib3/filepost.py
@@ -72,7 +72,7 @@ def encode_multipart_formdata(fields, boundary=None):
         boundary = choose_boundary()
 
     for field in iter_field_objects(fields):
-        body.write(b('--%s\r\n' % (boundary)))
+        body.write(b('--{0!s}\r\n'.format((boundary))))
 
         writer(body).write(field.render_headers())
         data = field.data
@@ -87,8 +87,8 @@ def encode_multipart_formdata(fields, boundary=None):
 
         body.write(b'\r\n')
 
-    body.write(b('--%s--\r\n' % (boundary)))
+    body.write(b('--{0!s}--\r\n'.format((boundary))))
 
-    content_type = str('multipart/form-data; boundary=%s' % boundary)
+    content_type = str('multipart/form-data; boundary={0!s}'.format(boundary))
 
     return body.getvalue(), content_type

--- a/requests/packages/urllib3/packages/ordered_dict.py
+++ b/requests/packages/urllib3/packages/ordered_dict.py
@@ -32,7 +32,7 @@ class OrderedDict(dict):
 
         '''
         if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+            raise TypeError('expected at most 1 arguments, got {0:d}'.format(len(args)))
         try:
             self.__root
         except AttributeError:
@@ -202,8 +202,8 @@ class OrderedDict(dict):
         _repr_running[call_key] = 1
         try:
             if not self:
-                return '%s()' % (self.__class__.__name__,)
-            return '%s(%r)' % (self.__class__.__name__, self.items())
+                return '{0!s}()'.format(self.__class__.__name__)
+            return '{0!s}({1!r})'.format(self.__class__.__name__, self.items())
         finally:
             del _repr_running[call_key]
 

--- a/requests/packages/urllib3/packages/six.py
+++ b/requests/packages/urllib3/packages/six.py
@@ -199,7 +199,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {0!r}".format(name))
 
 
 if PY3:

--- a/requests/packages/urllib3/poolmanager.py
+++ b/requests/packages/urllib3/poolmanager.py
@@ -186,7 +186,7 @@ class PoolManager(RequestMethods):
         kw['retries'] = retries
         kw['redirect'] = redirect
 
-        log.info("Redirecting %s -> %s" % (url, redirect_location))
+        log.info("Redirecting {0!s} -> {1!s}".format(url, redirect_location))
         return self.urlopen(method, redirect_location, **kw)
 
 
@@ -221,7 +221,7 @@ class ProxyManager(PoolManager):
                  proxy_headers=None, **connection_pool_kw):
 
         if isinstance(proxy_url, HTTPConnectionPool):
-            proxy_url = '%s://%s:%i' % (proxy_url.scheme, proxy_url.host,
+            proxy_url = '{0!s}://{1!s}:{2:d}'.format(proxy_url.scheme, proxy_url.host,
                                         proxy_url.port)
         proxy = parse_url(proxy_url)
         if not proxy.port:

--- a/requests/packages/urllib3/response.py
+++ b/requests/packages/urllib3/response.py
@@ -241,7 +241,7 @@ class HTTPResponse(io.IOBase):
 
             except (HTTPException, SocketError) as e:
                 # This includes IncompleteRead.
-                raise ProtocolError('Connection broken: %r' % e, e)
+                raise ProtocolError('Connection broken: {0!r}'.format(e), e)
 
         except Exception:
             # The response may not be closed but we're not going to use it anymore

--- a/requests/packages/urllib3/util/retry.py
+++ b/requests/packages/urllib3/util/retry.py
@@ -153,7 +153,7 @@ class Retry(object):
 
         redirect = bool(redirect) and None
         new_retries = cls(retries, redirect=redirect)
-        log.debug("Converted retries value: %r -> %r" % (retries, new_retries))
+        log.debug("Converted retries value: {0!r} -> {1!r}".format(retries, new_retries))
         return new_retries
 
     def get_backoff_time(self):
@@ -272,7 +272,7 @@ class Retry(object):
         if new_retry.is_exhausted():
             raise MaxRetryError(_pool, url, error or ResponseError(cause))
 
-        log.debug("Incremented Retry for (url='%s'): %r" % (url, new_retry))
+        log.debug("Incremented Retry for (url='{0!s}'): {1!r}".format(url, new_retry))
 
         return new_retry
 

--- a/requests/packages/urllib3/util/timeout.py
+++ b/requests/packages/urllib3/util/timeout.py
@@ -100,7 +100,7 @@ class Timeout(object):
         self._start_connect = None
 
     def __str__(self):
-        return '%s(connect=%r, read=%r, total=%r)' % (
+        return '{0!s}(connect={1!r}, read={2!r}, total={3!r})'.format(
             type(self).__name__, self._connect, self._read, self.total)
 
     @classmethod

--- a/requests/packages/urllib3/util/url.py
+++ b/requests/packages/urllib3/util/url.py
@@ -40,7 +40,7 @@ class Url(namedtuple('Url', url_attrs)):
     def netloc(self):
         """Network location including host and port"""
         if self.port:
-            return '%s:%d' % (self.host, self.port)
+            return '{0!s}:{1:d}'.format(self.host, self.port)
         return self.host
 
     @property

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -110,7 +110,7 @@ class SessionRedirectMixin(object):
                 resp.raw.read(decode_content=False)
 
             if i >= self.max_redirects:
-                raise TooManyRedirects('Exceeded %s redirects.' % self.max_redirects, response=resp)
+                raise TooManyRedirects('Exceeded {0!s} redirects.'.format(self.max_redirects), response=resp)
 
             # Release the connection back into the pool.
             resp.close()
@@ -120,7 +120,7 @@ class SessionRedirectMixin(object):
             # Handle redirection without scheme (see: RFC 1808 Section 4)
             if url.startswith('//'):
                 parsed_rurl = urlparse(resp.url)
-                url = '%s:%s' % (parsed_rurl.scheme, url)
+                url = '{0!s}:{1!s}'.format(parsed_rurl.scheme, url)
 
             # The scheme should be lower case...
             parsed = urlparse(url)
@@ -649,7 +649,7 @@ class Session(SessionRedirectMixin):
                 return adapter
 
         # Nothing matches :-/
-        raise InvalidSchema("No connection adapters were found for '%s'" % url)
+        raise InvalidSchema("No connection adapters were found for '{0!s}'".format(url))
 
     def close(self):
         """Closes all adapters and as such the session"""

--- a/requests/structures.py
+++ b/requests/structures.py
@@ -93,7 +93,7 @@ class LookupDict(dict):
         super(LookupDict, self).__init__()
 
     def __repr__(self):
-        return '<lookup \'%s\'>' % (self.name)
+        return '<lookup \'{0!s}\'>'.format((self.name))
 
     def __getitem__(self, key):
         # We allow fall-through here, so values default to None

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -436,7 +436,7 @@ def unquote_unreserved(uri):
             try:
                 c = chr(int(h, 16))
             except ValueError:
-                raise InvalidURL("Invalid percent-escape sequence: '%s'" % h)
+                raise InvalidURL("Invalid percent-escape sequence: '{0!s}'".format(h))
 
             if c in UNRESERVED_SET:
                 parts[i] = c + parts[i][2:]
@@ -586,7 +586,7 @@ def select_proxy(url, proxies):
 
 def default_user_agent(name="python-requests"):
     """Return a string representing the default user agent."""
-    return '%s/%s' % (name, __version__)
+    return '{0!s}/{1!s}'.format(name, __version__)
 
 
 def default_headers():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:requests?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:requests?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
